### PR TITLE
Fix polygon exemple

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ render(
 	<ReactRough width={200} height={400}>
 		<ReactRough.Circle points={[50, 50, 80]} fill="red" />
 		<ReactRough.Polygon
-			points={[[690, 130], [790, 140], [750, 240], [690, 220]]}
+			points={[[[690, 130], [790, 140], [750, 240], [690, 220]]]}
 			fill="blue"
 			stroke="green"
 		/>


### PR DESCRIPTION
Since `rough.polygon` takes a first `points` argument which is list of list and the points argument is given with a splat: https://github.com/ooade/react-rough/blob/master/src/index.js#L50

This api is not optimal though