### PR TITLE
Export components

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -9,7 +9,7 @@ exports[`ReactRough Arc should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Arc
       fill="red"
       points={
         Array [
@@ -30,7 +30,7 @@ exports[`ReactRough Arc should render properly with props 1`] = `
         }
         type="arc"
       />
-    </Component>
+    </Arc>
   </canvas>
 </ReactRough>
 `;
@@ -44,7 +44,7 @@ exports[`ReactRough Circle should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Circle
       fill="red"
       points={
         Array [
@@ -65,7 +65,7 @@ exports[`ReactRough Circle should render properly with props 1`] = `
         }
         type="circle"
       />
-    </Component>
+    </Circle>
   </canvas>
 </ReactRough>
 `;
@@ -104,7 +104,7 @@ exports[`ReactRough Core should render properly with children 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Circle
       fill="red"
       points={
         Array [
@@ -125,7 +125,7 @@ exports[`ReactRough Core should render properly with children 1`] = `
         }
         type="circle"
       />
-    </Component>
+    </Circle>
   </canvas>
 </ReactRough>
 `;
@@ -139,7 +139,7 @@ exports[`ReactRough Curve should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Curve
       fill="red"
       points={
         Array [
@@ -314,7 +314,7 @@ exports[`ReactRough Curve should render properly with props 1`] = `
         }
         type="curve"
       />
-    </Component>
+    </Curve>
   </canvas>
 </ReactRough>
 `;
@@ -328,7 +328,7 @@ exports[`ReactRough Ellipse should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Ellipse
       fill="blue"
       points={
         Array [
@@ -353,7 +353,7 @@ exports[`ReactRough Ellipse should render properly with props 1`] = `
         stroke="red"
         type="ellipse"
       />
-    </Component>
+    </Ellipse>
   </canvas>
 </ReactRough>
 `;
@@ -367,7 +367,7 @@ exports[`ReactRough Line should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Line
       fill="blue"
       points={
         Array [
@@ -392,7 +392,7 @@ exports[`ReactRough Line should render properly with props 1`] = `
         stroke="red"
         type="line"
       />
-    </Component>
+    </Line>
   </canvas>
 </ReactRough>
 `;
@@ -406,7 +406,7 @@ exports[`ReactRough Path should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Path
       dataString="M80 80 A 45 45, 0, 0, 0, 125 125 L 125 80 Z"
       fill="blue"
       stroke="red"
@@ -417,7 +417,7 @@ exports[`ReactRough Path should render properly with props 1`] = `
         stroke="red"
         type="path"
       />
-    </Component>
+    </Path>
   </canvas>
 </ReactRough>
 `;
@@ -431,7 +431,7 @@ exports[`ReactRough Polygon should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Polygon
       fill="blue"
       points={
         Array [
@@ -480,7 +480,7 @@ exports[`ReactRough Polygon should render properly with props 1`] = `
         stroke="red"
         type="polygon"
       />
-    </Component>
+    </Polygon>
   </canvas>
 </ReactRough>
 `;
@@ -494,7 +494,7 @@ exports[`ReactRough Rectangle should render properly with props 1`] = `
     height={400}
     width={200}
   >
-    <Component
+    <Rectangle
       fill="blue"
       points={
         Array [
@@ -519,7 +519,7 @@ exports[`ReactRough Rectangle should render properly with props 1`] = `
         stroke="red"
         type="rectangle"
       />
-    </Component>
+    </Rectangle>
   </canvas>
 </ReactRough>
 `;

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -8,6 +8,7 @@ import ReactRough, {
 	Curve,
 	Ellipse,
 	Line,
+	LinearPath,
 	Path,
 	Polygon,
 	Rectangle
@@ -204,7 +205,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.LinearPath
+					<LinearPath
 						points={[[690, 130], [790, 140], [750, 240], [690, 220]]}
 						fill="blue"
 						stroke="red"

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,16 @@ import React from 'react';
 import { configure, mount, render } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-import ReactRough from '../src';
+import ReactRough, {
+	Arc,
+	Circle,
+	Curve,
+	Ellipse,
+	Line,
+	Path,
+	Polygon,
+	Rectangle
+} from '../src';
 
 configure({ adapter: new Adapter() });
 
@@ -28,7 +37,7 @@ describe('ReactRough', () => {
 		it('should render properly with children', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Circle points={[50, 50, 80]} fill="red" />
+					<Circle points={[50, 50, 80]} fill="red" />
 				</ReactRough>
 			);
 			expect(wrapper).toMatchSnapshot();
@@ -40,7 +49,7 @@ describe('ReactRough', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
 					<SomeComponent>
-						<ReactRough.Circle points={[50, 50, 80]} fill="red" />
+						<Circle points={[50, 50, 80]} fill="red" />
 					</SomeComponent>
 				</ReactRough>
 			);
@@ -49,7 +58,7 @@ describe('ReactRough', () => {
 
 		it('should throw an error if the Provider component isnt found', () => {
 			expect(() =>
-				mount(<ReactRough.Circle points={[50, 50, 80]} fill="red" />)
+				mount(<Circle points={[50, 50, 80]} fill="red" />)
 			).toThrowError('ReactRough Component not found!');
 		});
 
@@ -57,7 +66,7 @@ describe('ReactRough', () => {
 			expect(() =>
 				mount(
 					<ReactRough width={200} height={400}>
-						<ReactRough.Circle points={[50, 50, 80]} fsill="red" />
+						<Circle points={[50, 50, 80]} fsill="red" />
 					</ReactRough>
 				)
 			).toThrowError('Invalid key "fsill" assigned to "circle component"');
@@ -68,7 +77,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Arc points={[50, 50, 80]} fill="red" />
+					<Arc points={[50, 50, 80]} fill="red" />
 				</ReactRough>
 			);
 
@@ -80,7 +89,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Circle points={[50, 50, 80]} fill="red" />
+					<Circle points={[50, 50, 80]} fill="red" />
 				</ReactRough>
 			);
 
@@ -101,7 +110,7 @@ describe('ReactRough', () => {
 
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Curve points={points} fill="red" />
+					<Curve points={points} fill="red" />
 				</ReactRough>
 			);
 
@@ -113,11 +122,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Ellipse
-						points={[10, 50, 150, 80]}
-						fill="blue"
-						stroke="red"
-					/>
+					<Ellipse points={[10, 50, 150, 80]} fill="blue" stroke="red" />
 				</ReactRough>
 			);
 
@@ -129,11 +134,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Line
-						points={[60, 60, 190, 60]}
-						fill="blue"
-						stroke="red"
-					/>
+					<Line points={[60, 60, 190, 60]} fill="blue" stroke="red" />
 				</ReactRough>
 			);
 
@@ -145,7 +146,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Path
+					<Path
 						dataString="M80 80 A 45 45, 0, 0, 0, 125 125 L 125 80 Z"
 						fill="blue"
 						stroke="red"
@@ -160,7 +161,7 @@ describe('ReactRough', () => {
 			expect(() => {
 				mount(
 					<ReactRough width={200} height={400}>
-						<ReactRough.Path
+						<Path
 							points="M80 80 A 45 45, 0, 0, 0, 125 125 L 125 80 Z"
 							fill="blue"
 							stroke="red"
@@ -175,7 +176,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Polygon
+					<Polygon
 						points={[[690, 130], [790, 140], [750, 240], [690, 220]]}
 						fill="blue"
 						stroke="red"
@@ -191,11 +192,7 @@ describe('ReactRough', () => {
 		it('should render properly with props', () => {
 			const wrapper = mount(
 				<ReactRough width={200} height={400}>
-					<ReactRough.Rectangle
-						points={[10, 10, 100, 100]}
-						fill="blue"
-						stroke="red"
-					/>
+					<Rectangle points={[10, 10, 100, 100]} fill="blue" stroke="red" />
 				</ReactRough>
 			);
 

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,8 @@ export const Line = props => <RoughConsumer type="line" {...props} />;
 
 export const Path = props => <RoughConsumer type="path" {...props} />;
 
+export const LinearPath = props => <RoughConsumer type="linearPath" {...props} />;
+
 export const Polygon = props => <RoughConsumer type="polygon" {...props} />;
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,40 +56,24 @@ export const RoughConsumer = ({ type, dataString, points, ...data }) => (
 	</RoughContext.Consumer>
 );
 
+export const Arc = props => <RoughConsumer type="arc" {...props} />;
+
+export const Circle = props => <RoughConsumer type="circle" {...props} />;
+
+export const Curve = props => <RoughConsumer type="curve" {...props} />;
+
+export const Ellipse = props => <RoughConsumer type="ellipse" {...props} />;
+
+export const Line = props => <RoughConsumer type="line" {...props} />;
+
+export const Path = props => <RoughConsumer type="path" {...props} />;
+
+export const Polygon = props => <RoughConsumer type="polygon" {...props} />;
+
+export const Rectangle = props => <RoughConsumer type="rectangle" {...props} />;
+
 class ReactRough extends React.Component {
 	canvasRef = React.createRef();
-
-	static Arc = props => {
-		return <RoughConsumer type="arc" {...props} />;
-	};
-
-	static Circle = props => {
-		return <RoughConsumer type="circle" {...props} />;
-	};
-
-	static Curve = props => {
-		return <RoughConsumer type="curve" {...props} />;
-	};
-
-	static Ellipse = props => {
-		return <RoughConsumer type="ellipse" {...props} />;
-	};
-
-	static Line = props => {
-		return <RoughConsumer type="line" {...props} />;
-	};
-
-	static Path = props => {
-		return <RoughConsumer type="path" {...props} />;
-	};
-
-	static Polygon = props => {
-		return <RoughConsumer type="polygon" {...props} />;
-	};
-
-	static Rectangle = props => {
-		return <RoughConsumer type="rectangle" {...props} />;
-	};
 
 	componentDidMount() {
 		const rc = Rough.canvas(this.canvasRef.current);


### PR DESCRIPTION
By exporting the components, we can take advantage of the powerful tree-shaking feature which will omit the unused parts of code -- making the overall app size even smaller.

Also the components are now named, because the `displayName` component property can be inferred from the `const` expression, but not from the `static` class member. (as seen in the changed snapshots :))