### PR TITLE
docs: Correct typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@
 #### npm
 
 ```sh
-npm add react-rough roughjs
+npm install react-rough roughjs
 ```
+
 or
+
 #### yarn
+
 ```sh
 yarn add react-rough roughjs
 ```
-
 
 ### Render a Rectangle on a canvas element
 


### PR DESCRIPTION
Correct `npm` installation command
```sh
npm install react-rough rough
```
npm uses `npm install <package-name>` or `npm i <package-name>` not `npm add ...`